### PR TITLE
Add custom data support, for use by addon mods.

### DIFF
--- a/src/main/java/se/mickelus/tetra/module/data/ModuleData.java
+++ b/src/main/java/se/mickelus/tetra/module/data/ModuleData.java
@@ -33,9 +33,14 @@ public class ModuleData {
     public ModuleVariantData[] variants = new ModuleVariantData[0];
 
     /**
-     * Custom data for use by addon mods. Use whatever Json format the addon requires.
+     * Custom data for use by addon mods. Consult the addon mod for details on their own format.
+     *
+     * Json format:
+     * {
+     *     "example_mod:custom_data": (format specified by addon mod)
+     * }
      */
-    public Map<String, Object> custom = new HashMap<>();
+    public Map<ResourceLocation, Object> custom = new HashMap<>();
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Non-configurable stuff below

--- a/src/main/java/se/mickelus/tetra/module/data/ModuleData.java
+++ b/src/main/java/se/mickelus/tetra/module/data/ModuleData.java
@@ -5,6 +5,8 @@ import se.mickelus.tetra.module.Priority;
 import se.mickelus.tetra.util.Filter;
 
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
 
@@ -29,6 +31,11 @@ public class ModuleData {
     public ResourceLocation tweakKey;
     public ResourceLocation[] improvements = new ResourceLocation[0];
     public ModuleVariantData[] variants = new ModuleVariantData[0];
+
+    /**
+     * Custom data for use by addon mods. Use whatever Json format the addon requires.
+     */
+    public Map<String, Object> custom = new HashMap<>();
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Non-configurable stuff below

--- a/src/main/java/se/mickelus/tetra/module/data/ModuleVariantData.java
+++ b/src/main/java/se/mickelus/tetra/module/data/ModuleVariantData.java
@@ -153,9 +153,14 @@ public class ModuleVariantData {
     public int magicCapacity = 0;
 
     /**
-     * Custom data for use by addon mods. Use whatever Json format the addon requires.
+     * Custom data for use by addon mods. Consult the addon mod for details on their own format.
+     *
+     * Json format:
+     * {
+     *     "example_mod:custom_data": (format specified by addon mod)
+     * }
      */
-    public Map<String, Object> custom = new HashMap<>();
+    public Map<ResourceLocation, Object> custom = new HashMap<>();
 
     public String getKey() {
         return key;

--- a/src/main/java/se/mickelus/tetra/module/data/ModuleVariantData.java
+++ b/src/main/java/se/mickelus/tetra/module/data/ModuleVariantData.java
@@ -4,6 +4,9 @@ import net.minecraft.util.ResourceLocation;
 import se.mickelus.tetra.TetraMod;
 import se.mickelus.tetra.module.Priority;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * ModuleVariantData contain stats and information for a variant of an item module.
  * Example json:
@@ -148,6 +151,11 @@ public class ModuleVariantData {
     public ModuleModel[] models = new ModuleModel[0];
 
     public int magicCapacity = 0;
+
+    /**
+     * Custom data for use by addon mods. Use whatever Json format the addon requires.
+     */
+    public Map<String, Object> custom = new HashMap<>();
 
     public String getKey() {
         return key;

--- a/src/main/java/se/mickelus/tetra/module/data/TweakData.java
+++ b/src/main/java/se/mickelus/tetra/module/data/TweakData.java
@@ -1,5 +1,6 @@
 package se.mickelus.tetra.module.data;
 
+import net.minecraft.util.ResourceLocation;
 import se.mickelus.tetra.capabilities.Capability;
 import se.mickelus.tetra.module.ItemEffect;
 
@@ -56,11 +57,11 @@ public class TweakData {
         return baseStats.magicCapacity + step * stepStats.magicCapacity;
     }
 
-    public Map<String, Object> getBaseStatsCustom() {
+    public Map<ResourceLocation, Object> getBaseStatsCustom() {
         return baseStats.custom;
     }
 
-    public Map<String, Object> getStepStatsCustom() {
+    public Map<ResourceLocation, Object> getStepStatsCustom() {
         return stepStats.custom;
     }
 }

--- a/src/main/java/se/mickelus/tetra/module/data/TweakData.java
+++ b/src/main/java/se/mickelus/tetra/module/data/TweakData.java
@@ -3,6 +3,8 @@ package se.mickelus.tetra.module.data;
 import se.mickelus.tetra.capabilities.Capability;
 import se.mickelus.tetra.module.ItemEffect;
 
+import java.util.Map;
+
 public class TweakData {
     public String variant;
     public String improvement;
@@ -52,5 +54,13 @@ public class TweakData {
 
     public int getMagicCapacity(int step) {
         return baseStats.magicCapacity + step * stepStats.magicCapacity;
+    }
+
+    public Map<String, Object> getBaseStatsCustom() {
+        return baseStats.custom;
+    }
+
+    public Map<String, Object> getStepStatsCustom() {
+        return stepStats.custom;
     }
 }


### PR DESCRIPTION
`ModuleVariantData` and `ModuleData` now have a `custom` field, mapping resource locations to objects. This should be sufficient and suitable for any addons that require additional data to be associated with modules, or associated with `ModuleVariantData` and subclasses.