### PR TITLE
Added explicit keybind for booster

### DIFF
--- a/src/main/java/se/mickelus/tetra/items/toolbelt/booster/JumpHandlerBooster.java
+++ b/src/main/java/se/mickelus/tetra/items/toolbelt/booster/JumpHandlerBooster.java
@@ -2,39 +2,44 @@ package se.mickelus.tetra.items.toolbelt.booster;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.settings.KeyBinding;
+import net.minecraftforge.client.settings.KeyConflictContext;
+import net.minecraftforge.fml.client.registry.ClientRegistry;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.InputEvent;
+import org.lwjgl.input.Keyboard;
 import se.mickelus.tetra.network.PacketHandler;
+
+import static se.mickelus.tetra.items.toolbelt.OverlayToolbelt.bindingGroup;
 
 public class JumpHandlerBooster {
 
     private final Minecraft mc;
 
-    private KeyBinding jumpKey;
+    public static final KeyBinding BOOST_BINDING = new KeyBinding("toolbelt.binding.boost", KeyConflictContext.IN_GAME, Keyboard.KEY_SPACE, bindingGroup);
 
-    private boolean wasJumpKeyDown = false;
+    private boolean wasBoostKeyDown = false;
 
     public JumpHandlerBooster(Minecraft mc) {
         this.mc = mc;
-        jumpKey = mc.gameSettings.keyBindJump;
+        ClientRegistry.registerKeyBinding(BOOST_BINDING);
     }
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onKeyInput(InputEvent.KeyInputEvent event) {
         if (mc.inGameHasFocus) {
-            if (jumpKey.isKeyDown() && mc.player.onGround && mc.player.isSneaking()) {
+            if (BOOST_BINDING.isKeyDown() && mc.player.onGround && mc.player.isSneaking()) {
                 UpdateBoosterPacket packet = new UpdateBoosterPacket(true, true);
                 PacketHandler.sendToServer(packet);
-            } else if (jumpKey.isKeyDown() && !wasJumpKeyDown && !mc.player.onGround) {
+            } else if (BOOST_BINDING.isKeyDown() && !wasBoostKeyDown && !mc.player.onGround) {
                 UpdateBoosterPacket packet = new UpdateBoosterPacket(true);
                 PacketHandler.sendToServer(packet);
-            } else if (!jumpKey.isKeyDown() && wasJumpKeyDown) {
+            } else if (!BOOST_BINDING.isKeyDown() && wasBoostKeyDown) {
                 UpdateBoosterPacket packet = new UpdateBoosterPacket(false);
                 PacketHandler.sendToServer(packet);
             }
 
-            wasJumpKeyDown = jumpKey.isKeyDown();
+            wasBoostKeyDown = BOOST_BINDING.isKeyDown();
         }
     }
 

--- a/src/main/java/se/mickelus/tetra/items/toolbelt/booster/UpdateBoosterPacket.java
+++ b/src/main/java/se/mickelus/tetra/items/toolbelt/booster/UpdateBoosterPacket.java
@@ -40,6 +40,7 @@ public class UpdateBoosterPacket extends AbstractPacket {
         ItemStack itemStack = UtilToolbelt.findToolbelt(player);
 
         if (!itemStack.isEmpty() && UtilBooster.canBoost(itemStack)) {
+            player.jump();
             UtilBooster.setActive(NBTHelper.getTag(itemStack), active, charged);
 
             UtilToolbelt.updateBauble(player);

--- a/src/main/resources/assets/tetra/lang/en_US.lang
+++ b/src/main/resources/assets/tetra/lang/en_US.lang
@@ -1936,6 +1936,7 @@ toolbelt.blocked=Inventory full, make space first
 toolbelt.binding.group=Tetra toolbelt
 toolbelt.binding.access=Quick access
 toolbelt.binding.restock=Restock
+toolbelt.binding.boost=Boost
 
 toolbelt.effect.tooltip.quick.quickAccess=A suitable tool can be quickly drawn from this slot
 toolbelt.effect.tooltip.quiver.quickAccess=Arrows can be drawn straight from this slot
@@ -2090,11 +2091,11 @@ quiver/hide=Hide quiver
 ###############################
 
 booster_schema.name=Booster
-booster_schema.description=Attach a booster unit, which grants the ability to jump long distances or even fly for shorter periods of time. Activate by crouching before a jump, or by jumping mid air or while flying with an elytra. §oUses gunpowder from toolbelt inventories as fuel.
+booster_schema.description=Attach a booster unit, which grants the ability to jump long distances or even fly for shorter periods of time. §oUses gunpowder from toolbelt inventories as fuel.
 booster_schema.slot1=Material
 
 toolbelt/booster.name=Booster
-toolbelt/booster.description=A booster unit which grants the ability to jump long distances or even fly for shorter periods of time. Activate by crouching before a jump, or by jumping mid air or while flying with an elytra. §oUses gunpowder from toolbelt inventories as fuel.
+toolbelt/booster.description=A booster unit which grants the ability to jump long distances or even fly for shorter periods of time. §oUses gunpowder from toolbelt inventories as fuel.
 
 booster/iron=Booster unit
 


### PR DESCRIPTION
Reason:
Several other mods in my modpack add behavior to the jump key, or to a keybinding that really only makes sense being bound to the same key as jump (eg. the wall-jump mod, because tapping/holding space 2+ times in quick succession is much easier than mixing another key in).

Behavior when the new keybind is bound to the same key as jump is identical to previous behavior.

Behavior when using a different keybind is *very nearly identical*.  The rest of this post expands on that point.

Technically you're carried ever-so-slightly further upwards if jump is bound to the same key (about 1/2 block?) when sneak-boosting straight upwards (holding sneak for the duration).
* This is not due to lack of jumping.  I can confirm the call to the jump() method is working...because without it, you barely leave the ground.
* I can also confirm that when bound to the same key as jump, it is not "double jumping" at the start of the boost, because vertical gain for the same-as-jump keybind is identical with or without the extra jump() call.

And that was as much looking-into as I thought it was worth, for a ~1/2 block difference after boosting up 10~11 blocks (especially since you gain extra height based on how quickly you release sneak once airborne).