### PR TITLE
Fix ForgedContainerTile NPE with PneumaticCraft Block Tracker

### DIFF
--- a/src/main/java/se/mickelus/tetra/blocks/forged/container/ForgedContainerBlock.java
+++ b/src/main/java/se/mickelus/tetra/blocks/forged/container/ForgedContainerBlock.java
@@ -129,7 +129,7 @@ public class ForgedContainerBlock extends TetraWaterloggedBlock implements IInte
     private static boolean breakLock(World world, BlockPos pos, @Nullable PlayerEntity player, int index, @Nullable Hand hand) {
         ForgedContainerTile te = (ForgedContainerTile) world.getTileEntity(pos);
         if (te != null) {
-            te.getOrDelegate().breakLock(player, index, hand);
+            te.getOrDelegate().ifPresent(primary -> primary.breakLock(player, index, hand));
         }
 
         return true;
@@ -138,7 +138,7 @@ public class ForgedContainerBlock extends TetraWaterloggedBlock implements IInte
     private static boolean open(World world, BlockPos pos, BlockState blockState, PlayerEntity player, Hand hand, Direction facing) {
         ForgedContainerTile te = (ForgedContainerTile) world.getTileEntity(pos);
         if (te != null) {
-            te.getOrDelegate().open(player);
+            te.getOrDelegate().ifPresent(primary -> primary.open(player));
         }
 
         return true;
@@ -158,10 +158,10 @@ public class ForgedContainerBlock extends TetraWaterloggedBlock implements IInte
         if (didInteract != ActionResultType.SUCCESS) {
             if (!world.isRemote) {
                 TileEntityOptional.from(world, pos, ForgedContainerTile.class)
-                        .ifPresent(te -> {
-                            ForgedContainerTile delegate = te.getOrDelegate();
-                            if (delegate.isOpen()) {
-                                NetworkHooks.openGui((ServerPlayerEntity) player, delegate, delegate.getPos());
+                        .flatMap(ForgedContainerTile::getOrDelegate)
+                        .ifPresent(primary -> {
+                            if (primary.isOpen()) {
+                                NetworkHooks.openGui((ServerPlayerEntity) player, primary, primary.getPos());
                             }
                         });
             }

--- a/src/main/java/se/mickelus/tetra/blocks/forged/container/ForgedContainerTile.java
+++ b/src/main/java/se/mickelus/tetra/blocks/forged/container/ForgedContainerTile.java
@@ -62,19 +62,18 @@ public class ForgedContainerTile extends TileEntity implements INamedContainerPr
         lockIntegrity = new int[lockCount];
     }
 
-    public ForgedContainerTile getOrDelegate() {
+    public Optional<ForgedContainerTile> getOrDelegate() {
         if (world != null && getBlockState().getBlock() instanceof ForgedContainerBlock && isFlipped()) {
-            return TileEntityOptional.from(world, pos.offset(getFacing().rotateYCCW()), ForgedContainerTile.class)
-                    .orElse(null);
+            return TileEntityOptional.from(world, pos.offset(getFacing().rotateYCCW()), ForgedContainerTile.class);
         }
-        return this;
+        return Optional.of(this);
     }
 
     @Nonnull
     @Override
     public <T> LazyOptional<T> getCapability(@Nonnull net.minecraftforge.common.capabilities.Capability<T> cap, @Nullable Direction side) {
         if (cap == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
-            return getOrDelegate().handler.cast();
+            return getOrDelegate().map(primary -> primary.handler.<T>cast()).orElseGet(LazyOptional::empty);
         }
         return super.getCapability(cap, side);
     }


### PR DESCRIPTION
Couldn't seem to find the 1.16 branch for this mod so I've made this for what seems to be the 1.15 branch. I'd be happy to retarget for the 1.16 branch though.

Changes in PR:
- Made `ForgedContainerTile#getOrDelegate` return `Optional<ForgedContainerTile>` instead of returning null when not found
- Updated the places where the above was used to make use of the new return type

Mod versions:
- forge-1.16.5-36.0.14
- mgui-1.16.4-3.1.3
- tetra-1.16.4-3.6.0
- pneumaticcraft-repressurized-1.16.5-2.9.5-128

Steps to reproduce:
1. Set up Charging Station (10 Speed Upgrades) + Creative Compressor (19.9 bar)
2. Put Pneumatic Helmet inside the Charging Station and install a Block Tracker Upgrade inside the helmet
3. Wear the Pneumatic Helmet and open the UI with u
4. Enable the Block Tracker upgrade and enable Inventories
5. Place down a Forged Container
6. Break the left block of the Forged container

[Crash Report](https://gist.github.com/BlueAgent/368df3d7855a82b995d51566be7ca0ee)