### PR TITLE
Update pack.mcmeta for 1.18 from 1.16

### DIFF
--- a/src/main/resources/pack.mcmeta
+++ b/src/main/resources/pack.mcmeta
@@ -1,6 +1,6 @@
 {
     "pack": {
         "description": "tetra resources",
-        "pack_format": 6
+        "pack_format": 8
     }
 }


### PR DESCRIPTION
minecraft 1.18 uses pack format 8