### PR TITLE
Fix Quark Matrix Enchanting not applying enchants to Tetra tools correctly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -161,6 +161,10 @@ dependencies {
 //    compile fg.deobf("curse.maven:cursed:2913022")
 //    compile fg.deobf("curse.maven:cursed-bookshelf:2935828")
 
+//    compile fg.deobf("curse.maven:quark-243121:3578106")
+//    compile fg.deobf("curse.maven:quarkoddities-301051:3575623")
+//    compile fg.deobf("curse.maven:autoreglib-250363:3575622")
+
     annotationProcessor 'org.spongepowered:mixin:0.8.5:processor'
 }
 

--- a/src/main/java/se/mickelus/tetra/mixin/MixinEnchantmentHelper.java
+++ b/src/main/java/se/mickelus/tetra/mixin/MixinEnchantmentHelper.java
@@ -1,0 +1,26 @@
+package se.mickelus.tetra.mixin;
+
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.enchantment.Enchantment;
+import net.minecraft.world.item.enchantment.EnchantmentHelper;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import se.mickelus.tetra.aspect.TetraEnchantmentHelper;
+import se.mickelus.tetra.items.modular.IModularItem;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.Map;
+
+@ParametersAreNonnullByDefault
+@Mixin(EnchantmentHelper.class)
+public class MixinEnchantmentHelper {
+    @Inject(at = @At("RETURN"), method = "Lnet/minecraft/world/item/enchantment/EnchantmentHelper;setEnchantments(Ljava/util/Map;Lnet/minecraft/world/item/ItemStack;)V")
+    private static void setEnchantments(Map<Enchantment, Integer> enchantments, ItemStack itemStack, CallbackInfo ci) {
+        if (itemStack.getItem() instanceof IModularItem item) {
+            TetraEnchantmentHelper.mapEnchantments(itemStack);
+            item.assemble(itemStack, null, 0);
+        }
+    }
+}

--- a/src/main/resources/tetra.mixins.json
+++ b/src/main/resources/tetra.mixins.json
@@ -1,13 +1,14 @@
 {
     "required": true,
     "package": "se.mickelus.tetra.mixin",
-    "compatibilityLevel": "JAVA_8",
+    "compatibilityLevel": "JAVA_17",
     "refmap": "tetra.refmap.json",
     "mixins": [
         "MixinGrindstoneContainer",
         "MixinItemStack",
         "MixinPlayerEntity",
-        "MixinServerPlayNetHandler"
+        "MixinServerPlayNetHandler",
+        "MixinEnchantmentHelper"
     ],
     "minVersion": "0.8"
 }


### PR DESCRIPTION
Makes EnchantmentHelper assemble enchantments to Tetra tools correctly by copying the fix in MixinItemStack.