### PR TITLE
[I18n] Allow modular items not to show spaces in their names

### DIFF
--- a/src/main/java/se/mickelus/tetra/items/modular/IModularItem.java
+++ b/src/main/java/se/mickelus/tetra/items/modular/IModularItem.java
@@ -911,7 +911,7 @@ public interface IModularItem {
     }
 
     default String getDisplayNamePrefixes(ItemStack itemStack) {
-        return Stream.concat(
+        Stream<String> prefixStreamToReduce = Stream.concat(
                 Arrays.stream(getImprovements(itemStack))
                         .map(improvement -> improvement.key + ".prefix")
                         .filter(I18n::hasKey)
@@ -921,8 +921,11 @@ public interface IModularItem {
                         .map(module -> module.getItemPrefix(itemStack))
                         .filter(Objects::nonNull)
         )
-                .limit(2)
-                .reduce("", (result, prefix) -> result + prefix + " ");
+                .limit(2);
+        if (TranslationTextComponent("tetra.langSetting.noSpace") == "1") {
+            return prefixStreamToReduce.reduce("", (result, prefix) -> result + prefix);
+        }
+        return prefixStreamToReduce.reduce("", (result, prefix) -> result + prefix + " ");
     }
 
     default String getItemName(ItemStack itemStack) {

--- a/src/main/resources/assets/tetra/lang/ja_jp.json
+++ b/src/main/resources/assets/tetra/lang/ja_jp.json
@@ -1,0 +1,1 @@
+{"tetra.langSetting.noSpace": "1"}

--- a/src/main/resources/assets/tetra/lang/zh_cn.json
+++ b/src/main/resources/assets/tetra/lang/zh_cn.json
@@ -1,0 +1,1 @@
+{"tetra.langSetting.noSpace": "1"}

--- a/src/main/resources/assets/tetra/lang/zh_tw.json
+++ b/src/main/resources/assets/tetra/lang/zh_tw.json
@@ -1,5 +1,6 @@
 {
   "itemGroup.tetra":"Tetra",
+  "tetra.langSetting.noSpace": "1",
   "tetra.attribute.draw_strength.name":"拉弓力量",
   "tetra.attribute.draw_speed.name":"拉弓時間",
   "tetra.attribute.ability_damage.name":"特殊功能傷害",


### PR DESCRIPTION
Except English, there are many other languages in the world. When you hardcode anything about i18n/l10n, you should first consider if it is acceptable to speakers of other languages. In this case, Iron Sword is certainly acceptable to English speakers, 铁 剑 might be acceptable to some Chinese speakers but to most people it is ugly to show so (there should not be a space between iron(铁) and sword(剑), it should be shown as 铁剑), de Hierro Espada might be acceptable to a few Spanish speakers but more speakers would certainly choose Espada de Hierro (hierro is iron, ). Now suppose a language that has no space between the words of materials and weapons, places material prefixes in English as suffixes in itself, has grammatical genders, and most crucially is written right-to-left, how would you support this language? Maybe it is much too excessive to set such an extreme example, I am not here to ask the developer(s) to consider this deep, but it is indeed important to consider other languages.

I do not know how to code actually, but I thought providing pieces of code would show how I was thinking better, so I chose requesting pull instead of submitting an issue. If I am able to do so, I will support languages like French (has genders) and Spanish (has sequences of noun-modifying which is different from English), but I am not. So if the developer(s) of this mod have spare time, please consider optimizing how modular names are shown. When I say hardcode, it does not simply mean hardcoding strings, but also means hardcoding a mode (such as concat() only 2 strings but not 3) or a sequence.

Anyone has permission can close this pull request at any time. I do not really want the code to be merged because it would certainly cause errors.