### PR TITLE
Fix Amethyst item

### DIFF
--- a/src/main/resources/data/tetra/materials/gem/amethyst.json
+++ b/src/main/resources/data/tetra/materials/gem/amethyst.json
@@ -19,7 +19,7 @@
         "crude"
     ],
     "material": {
-        "items": [ "minecraft:amethyst" ]
+        "items": [ "minecraft:amethyst_shard" ]
     },
     "requiredTools": {
         "hammer_dig": "minecraft:stone"


### PR DESCRIPTION
I assume this was a mistake as there is no minecraft:amethyst, only minecraft:amethyst_shard which causes tetra to fail to load it as a material