### PR TITLE
Update CraftingEffectRegistry

### DIFF
--- a/src/main/java/se/mickelus/tetra/craftingeffect/CraftingEffectRegistry.java
+++ b/src/main/java/se/mickelus/tetra/craftingeffect/CraftingEffectRegistry.java
@@ -22,7 +22,7 @@ public class CraftingEffectRegistry {
     Map<String, Class<? extends CraftingEffectOutcome>> effectTypes = new HashMap<>();
 
     public CraftingEffectRegistry() {
-        instance = this;
+        if (instance!=null) { instance = this }
     }
 
     public static void registerConditionType(String identifier, Class<? extends CraftingEffectCondition> clazz) {


### PR DESCRIPTION
Made instancce only override if an instance is not present. Therefore, other mods will actually be able to register their own CraftingEffectOutcomes and Conditions