### PR TITLE
Fix toolbelt compatibility with Baubles API variants

### DIFF
--- a/src/main/java/se/mickelus/tetra/items/toolbelt/BaublesCompatibility.java
+++ b/src/main/java/se/mickelus/tetra/items/toolbelt/BaublesCompatibility.java
@@ -1,0 +1,68 @@
+package se.mickelus.tetra.items.toolbelt;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/** Runtime bridge for Baubles-compatible implementations that omit setPlayer. */
+public final class BaublesCompatibility {
+    private static final ConcurrentMap<Class<?>, Method> SET_PLAYER = new ConcurrentHashMap<>();
+    private static final Set<Class<?>> WITHOUT_SET_PLAYER =
+            Collections.newSetFromMap(new ConcurrentHashMap<Class<?>, Boolean>());
+
+    private BaublesCompatibility() { }
+
+    public static void setPlayerIfSupported(Object handler, Object player) {
+        Class<?> handlerClass = handler.getClass();
+        Method method = SET_PLAYER.get(handlerClass);
+
+        if (method == null && !WITHOUT_SET_PLAYER.contains(handlerClass)) {
+            method = resolve(handlerClass, player.getClass().getClassLoader());
+            if (method == null) {
+                WITHOUT_SET_PLAYER.add(handlerClass);
+            } else {
+                SET_PLAYER.put(handlerClass, method);
+            }
+        }
+
+        if (method != null) {
+            try {
+                method.invoke(handler, player);
+            } catch (IllegalAccessException e) {
+                throw new RuntimeException("Unable to invoke Baubles setPlayer", e);
+            } catch (InvocationTargetException e) {
+                Throwable cause = e.getCause();
+                if (cause instanceof RuntimeException) {
+                    throw (RuntimeException) cause;
+                }
+                if (cause instanceof Error) {
+                    throw (Error) cause;
+                }
+                throw new RuntimeException("Baubles setPlayer failed", cause);
+            }
+        }
+    }
+
+    private static Method resolve(Class<?> handlerClass, ClassLoader loader) {
+        try {
+            Class<?> livingBase = Class.forName(
+                    "net.minecraft.entity.EntityLivingBase",
+                    false,
+                    loader
+            );
+            try {
+                return handlerClass.getMethod("setPlayer", livingBase);
+            } catch (NoSuchMethodException ignored) {
+                return null;
+            }
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(
+                    "Unable to resolve EntityLivingBase for Baubles compatibility",
+                    e
+            );
+        }
+    }
+}

--- a/src/main/java/se/mickelus/tetra/items/toolbelt/UtilToolbelt.java
+++ b/src/main/java/se/mickelus/tetra/items/toolbelt/UtilToolbelt.java
@@ -146,7 +146,7 @@ public class UtilToolbelt {
             IBaublesItemHandler handler = player.getCapability(BaublesCapabilities.CAPABILITY_BAUBLES, null);
 
             if (handler != null) {
-                handler.setPlayer(player);
+                BaublesCompatibility.setPlayerIfSupported(handler, player);
                 IInventory baubleInventory = new BaublesInventoryWrapper(handler, player);
 
                 for (int i = 0; i < baubleInventory.getSizeInventory(); i++) {


### PR DESCRIPTION
## Problem
The 1.12 toolbelt integration directly invokes `IBaublesItemHandler#setPlayer`. Some Baubles-compatible implementations, including Bubbles 2.4.10, provide the capability without that legacy method, so the direct call can fail during toolbelt lookup.

## Fix
Route the optional `setPlayer(EntityLivingBase)` call through a small reflective compatibility bridge. Implementations that expose the method keep the existing behavior; implementations that omit it continue without the optional call.

## Validation
- Java 8 bridge harness: a legacy handler invokes `setPlayer`; a Bubbles-style handler without the method is a safe no-op.
- Runtime-tested in Minecraft 1.12.2 with Bubbles 2.4.10 in a 488-JAR integration set.
- Toolbelt lookup, world save/reload, and clean shutdown were verified.

Base branch reviewed: `1.12`
Base commit: `59488e4244c22a344d6191912a69fa099979a27b`
